### PR TITLE
Fix: spelling mistake in WARWF.tsx

### DIFF
--- a/app/src/layout/routes/index/WARWF.tsx
+++ b/app/src/layout/routes/index/WARWF.tsx
@@ -8,7 +8,7 @@ import { TbBulb, TbChecks } from "react-icons/tb";
 const items = [
 	{
 		id: 0,
-		title: "Minecrat server status",
+		title: "Minecraft server status",
 		description: "Check any Minecraft servers status on both, Java and Bedrock edition!",
 		to: "",
 		color: "green",


### PR DESCRIPTION
Changed a spelling mistake in WARWF.tsx.

title: "Minecrat server status", -> title: "Minecraft server status",